### PR TITLE
add appointment time domain

### DIFF
--- a/HousingRepairsOnlineApi.Tests/UseCasesTests/RetrieveAvailableAppointmentsUseCaseTests.cs
+++ b/HousingRepairsOnlineApi.Tests/UseCasesTests/RetrieveAvailableAppointmentsUseCaseTests.cs
@@ -121,14 +121,12 @@ namespace HousingRepairsOnlineApi.Tests.UseCasesTests
             var repairCode = "N373049";
             var startTime = DateTime.Today.AddHours(8);
             var endTime = DateTime.Today.AddHours(12);
-            var dummyRef = new Reference();
 
             sorEngineMock.Setup(x => x.MapSorCode(kitchen, cupboards, doorHangingOff)).Returns(repairCode);
 
             appointmentsGatewayMock.Setup(x => x.GetAvailableAppointments(repairCode, "uprn"))
                 .ReturnsAsync(new List<Appointment> { new()
                 {
-                    Reference = dummyRef,
                     TimeOfDay = new TimeOfDay
                     {
                         EarliestArrivalTime = startTime,
@@ -139,7 +137,6 @@ namespace HousingRepairsOnlineApi.Tests.UseCasesTests
             var actual = await sytemUndertest.Execute(kitchen, cupboards, doorHangingOff, "uprn");
             var actualAddress = actual.First();
 
-            Assert.Equal(dummyRef, actualAddress.Id);
             Assert.Equal(startTime, actualAddress.StartTime);
             Assert.Equal(endTime, actualAddress.EndTime);
         }

--- a/HousingRepairsOnlineApi.Tests/UseCasesTests/RetrieveAvailableAppointmentsUseCaseTests.cs
+++ b/HousingRepairsOnlineApi.Tests/UseCasesTests/RetrieveAvailableAppointmentsUseCaseTests.cs
@@ -1,7 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using FluentAssertions;
+using HACT.Dtos;
 using HousingRepairsOnlineApi.Gateways;
 using HousingRepairsOnlineApi.Helpers;
 using HousingRepairsOnlineApi.UseCases;
@@ -112,5 +114,35 @@ namespace HousingRepairsOnlineApi.Tests.UseCasesTests
             await sytemUndertest.Execute(kitchen, cupboards, doorHangingOff, "uprn");
             appointmentsGatewayMock.Verify(x => x.GetAvailableAppointments(repairCode, "uprn"), Times.Once);
         }
+
+        [Fact]
+        public async void GivenRepairParameters_WhenExecute_AppointmentTimeAreReturned()
+        {
+            var repairCode = "N373049";
+            var startTime = DateTime.Today.AddHours(8);
+            var endTime = DateTime.Today.AddHours(12);
+            var dummyRef = new Reference();
+
+            sorEngineMock.Setup(x => x.MapSorCode(kitchen, cupboards, doorHangingOff)).Returns(repairCode);
+
+            appointmentsGatewayMock.Setup(x => x.GetAvailableAppointments(repairCode, "uprn"))
+                .ReturnsAsync(new List<Appointment> { new()
+                {
+                    Reference = dummyRef,
+                    TimeOfDay = new TimeOfDay
+                    {
+                        EarliestArrivalTime = startTime,
+                        LatestArrivalTime = endTime
+                    },
+                } });
+
+            var actual = await sytemUndertest.Execute(kitchen, cupboards, doorHangingOff, "uprn");
+            var actualAddress = actual.First();
+
+            Assert.Equal(dummyRef, actualAddress.Id);
+            Assert.Equal(startTime, actualAddress.StartTime);
+            Assert.Equal(endTime, actualAddress.EndTime);
+        }
+
     }
 }

--- a/HousingRepairsOnlineApi/Controllers/AppointmentsController.cs
+++ b/HousingRepairsOnlineApi/Controllers/AppointmentsController.cs
@@ -17,9 +17,9 @@ namespace HousingRepairsOnlineApi.Controllers
 
         [HttpGet]
         [Route("AvailableAppointments")]
-        public async Task<IActionResult> AvailableAppointments([FromQuery] string repairLocation, [FromQuery] string repairProblem, [FromQuery] string repairIssue, [FromQuery] string uprn)
+        public async Task<IActionResult> AvailableAppointments([FromQuery] string repairLocation, [FromQuery] string repairProblem, [FromQuery] string repairIssue, [FromQuery] string locationId)
         {
-            var result = await retrieveAvailableAppointmentsUseCase.Execute(repairLocation, repairProblem, repairIssue, uprn);
+            var result = await retrieveAvailableAppointmentsUseCase.Execute(repairLocation, repairProblem, repairIssue, locationId);
             return Ok(result);
         }
     }

--- a/HousingRepairsOnlineApi/Domain/AppointmentTime.cs
+++ b/HousingRepairsOnlineApi/Domain/AppointmentTime.cs
@@ -1,11 +1,10 @@
 ﻿using System;
-using HACT.Dtos;
 
 namespace HousingRepairsOnlineApi.Domain
 {
     public class AppointmentTime
     {
-        public Reference Id { get; set; }
+        public string Id { get; set; }
         public DateTime StartTime { get; set; }
         public DateTime EndTime { get; set; }
     }

--- a/HousingRepairsOnlineApi/Domain/AppointmentTime.cs
+++ b/HousingRepairsOnlineApi/Domain/AppointmentTime.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using HACT.Dtos;
+
+namespace HousingRepairsOnlineApi.Domain
+{
+    public class AppointmentTime
+    {
+        public Reference Id { get; set; }
+        public DateTime StartTime { get; set; }
+        public DateTime EndTime { get; set; }
+    }
+}

--- a/HousingRepairsOnlineApi/UseCases/IRetrieveAvailableAppointmentsUseCase.cs
+++ b/HousingRepairsOnlineApi/UseCases/IRetrieveAvailableAppointmentsUseCase.cs
@@ -8,6 +8,6 @@ namespace HousingRepairsOnlineApi.UseCases
     public interface IRetrieveAvailableAppointmentsUseCase
     {
         public Task<List<AppointmentTime>> Execute(string repairLocation, string repairProblem, string repairIssue,
-            string uprn);
+            string locationId);
     }
 }

--- a/HousingRepairsOnlineApi/UseCases/IRetrieveAvailableAppointmentsUseCase.cs
+++ b/HousingRepairsOnlineApi/UseCases/IRetrieveAvailableAppointmentsUseCase.cs
@@ -1,11 +1,13 @@
 ﻿using System.Collections.Generic;
 using System.Threading.Tasks;
 using HACT.Dtos;
+using HousingRepairsOnlineApi.Domain;
 
 namespace HousingRepairsOnlineApi.UseCases
 {
     public interface IRetrieveAvailableAppointmentsUseCase
     {
-        public Task<IEnumerable<Appointment>> Execute(string repairLocation, string repairProblem, string repairIssue, string uprn);
+        public Task<List<AppointmentTime>> Execute(string repairLocation, string repairProblem, string repairIssue,
+            string uprn);
     }
 }

--- a/HousingRepairsOnlineApi/UseCases/IRetrieveAvailableAppointmentsUseCase.cs
+++ b/HousingRepairsOnlineApi/UseCases/IRetrieveAvailableAppointmentsUseCase.cs
@@ -1,6 +1,5 @@
 ﻿using System.Collections.Generic;
 using System.Threading.Tasks;
-using HACT.Dtos;
 using HousingRepairsOnlineApi.Domain;
 
 namespace HousingRepairsOnlineApi.UseCases

--- a/HousingRepairsOnlineApi/UseCases/RetrieveAvailableAppointmentsUseCase.cs
+++ b/HousingRepairsOnlineApi/UseCases/RetrieveAvailableAppointmentsUseCase.cs
@@ -21,18 +21,17 @@ namespace HousingRepairsOnlineApi.UseCases
         }
 
         public async Task<List<ApplicationTime>> Execute(string repairLocation, string repairProblem,
-            string repairIssue, string uprn)
+            string repairIssue, string locationId)
         {
             Guard.Against.NullOrWhiteSpace(repairLocation, nameof(repairLocation));
             Guard.Against.NullOrWhiteSpace(repairProblem, nameof(repairProblem));
             Guard.Against.NullOrWhiteSpace(repairIssue, nameof(repairIssue));
-            Guard.Against.NullOrWhiteSpace(uprn, nameof(uprn));
+            Guard.Against.NullOrWhiteSpace(locationId, nameof(locationId));
             var repairCode = sorEngine.MapSorCode(repairLocation, repairProblem, repairIssue);
 
-            var convertedResults = new List<ApplicationTime>();
 
-            var result = await appointmentsGateway.GetAvailableAppointments(repairCode, uprn);
-            convertedResults.AddRange(result.Select(ConvertToHactAppointment));
+            var result = await appointmentsGateway.GetAvailableAppointments(repairCode, locationId);
+            var convertedResults = result.Select(ConvertToHactAppointment).ToList();
 
             return convertedResults;
 
@@ -41,7 +40,6 @@ namespace HousingRepairsOnlineApi.UseCases
 
                 return new ApplicationTime
                 {
-                    Id = appointment.Reference,
                     StartTime = appointment.TimeOfDay.EarliestArrivalTime,
                     EndTime = appointment.TimeOfDay.LatestArrivalTime
                 };

--- a/HousingRepairsOnlineApi/UseCases/RetrieveAvailableAppointmentsUseCase.cs
+++ b/HousingRepairsOnlineApi/UseCases/RetrieveAvailableAppointmentsUseCase.cs
@@ -1,9 +1,11 @@
 ﻿using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using Ardalis.GuardClauses;
 using HACT.Dtos;
 using HousingRepairsOnlineApi.Gateways;
 using HousingRepairsOnlineApi.Helpers;
+using ApplicationTime = HousingRepairsOnlineApi.Domain.AppointmentTime;
 
 namespace HousingRepairsOnlineApi.UseCases
 {
@@ -18,16 +20,32 @@ namespace HousingRepairsOnlineApi.UseCases
             this.sorEngine = sorEngine;
         }
 
-        public async Task<IEnumerable<Appointment>> Execute(string repairLocation, string repairProblem, string repairIssue, string uprn)
+        public async Task<List<ApplicationTime>> Execute(string repairLocation, string repairProblem,
+            string repairIssue, string uprn)
         {
             Guard.Against.NullOrWhiteSpace(repairLocation, nameof(repairLocation));
             Guard.Against.NullOrWhiteSpace(repairProblem, nameof(repairProblem));
             Guard.Against.NullOrWhiteSpace(repairIssue, nameof(repairIssue));
             Guard.Against.NullOrWhiteSpace(uprn, nameof(uprn));
             var repairCode = sorEngine.MapSorCode(repairLocation, repairProblem, repairIssue);
-            var result = await appointmentsGateway.GetAvailableAppointments(repairCode, uprn);
 
-            return result;
+            var convertedResults = new List<ApplicationTime>();
+
+            var result = await appointmentsGateway.GetAvailableAppointments(repairCode, uprn);
+            convertedResults.AddRange(result.Select(ConvertToHactAppointment));
+
+            return convertedResults;
+
+            ApplicationTime ConvertToHactAppointment(Appointment appointment)
+            {
+
+                return new ApplicationTime
+                {
+                    Id = appointment.Reference,
+                    StartTime = appointment.TimeOfDay.EarliestArrivalTime,
+                    EndTime = appointment.TimeOfDay.LatestArrivalTime
+                };
+            }
         }
     }
 }


### PR DESCRIPTION
previously the appointments endpoint was returning a hact object, however the frontend expected an object that looks like this:
```json
[
    {
        "id": "d290f1ee-6c54-4b01-90e6-d701748f0851",
        "startTime": "2017-07-21T12:00:00Z",
        "endTime": "2017-07-21T17:00:00Z"
    },
    {
        "id": "8d1762b9-f6e7-43c5-86c2-778bacb602e2",
        "startTime": "2017-07-22T09:00:00Z",
        "endTime": "2017-07-22T12:00:00Z"
    },
    {
        "id": "b596d313-2b39-43ad-a76a-3b824eb56daf",
        "startTime": "2017-07-22T12:00:00Z",
        "endTime": "2017-07-22T17:00:00Z"
    }
]

```