### PR TITLE
allow repair request with no image

### DIFF
--- a/HousingRepairsOnlineApi/Properties/launchSettings.json
+++ b/HousingRepairsOnlineApi/Properties/launchSettings.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "$schema": "http://json.schemastore.org/launchsettings.json",
   "iisSettings": {
     "windowsAuthentication": false,
@@ -34,7 +34,7 @@
         "COSMOS_DATABASE_ID": "housing-repairs-online",
         "COSMOS_CONTAINER_ID": "repairs-requests",
         "AZURE_STORAGE_CONNECTION_STRING": "<REPLACE WITH AZURE STORAGE CONNECTION STRING>",
-        "STORAGE_CONTAINER_NAME": "housing-repairs-online"
+        "STORAGE_CONTAINER_NAME": "housing-repairs-online",
         "GOV_NOTIFY_KEY" : "<REPLACE WITH GOV NOTIFY API URL>",
         "CONFIRMATION_SMS_NOTIFY_TEMPLATE_ID": "<REPLACE WITH GOV NOTIFY SMS TEMPLATE ID>",
         "CONFIRMATION_EMAIL_NOTIFY_TEMPLATE_ID": "<REPLACE WITH GOV NOTIFY EMAIL TEMPLATE ID>"

--- a/HousingRepairsOnlineApi/UseCases/SaveRepairRequestUseCase.cs
+++ b/HousingRepairsOnlineApi/UseCases/SaveRepairRequestUseCase.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 using HousingRepairsOnlineApi.Domain;
 using HousingRepairsOnlineApi.Gateways;
 using HousingRepairsOnlineApi.Helpers;
@@ -22,11 +21,6 @@ namespace HousingRepairsOnlineApi.UseCases
 
         public async Task<string> Execute(RepairRequest repairRequest)
         {
-            var photoUrl = storageGateway.UploadBlob(
-                repairRequest.Description.Base64Img,
-                repairRequest.Description.FileExtension
-            ).Result;
-
             var repair = new Repair
             {
                 Address = repairRequest.Address,
@@ -40,13 +34,22 @@ namespace HousingRepairsOnlineApi.UseCases
                 Description = new RepairDescription
                 {
                     Text = repairRequest.Description.Text,
-                    PhotoUrl = photoUrl
                 },
                 SOR = sorEngine.MapSorCode(
                     repairRequest.Location.Value,
                     repairRequest.Problem.Value,
                     repairRequest.Issue.Value)
             };
+
+            if (!string.IsNullOrEmpty(repairRequest.Description.Base64Img))
+            {
+                var photoUrl = storageGateway.UploadBlob(
+                    repairRequest.Description.Base64Img,
+                    repairRequest.Description.FileExtension
+                ).Result;
+                repair.Description.PhotoUrl = photoUrl;
+
+            }
 
             var savedRequest = await cosmosGateway.AddRepair(repair);
 


### PR DESCRIPTION
we weren't checking if an image was being passed in, this caused an error because we were attempting to upload an image with no content 