### PR TITLE
Removed door lock from bedroom door options

### DIFF
--- a/HousingRepairsOnlineApi/SoRConfig.json
+++ b/HousingRepairsOnlineApi/SoRConfig.json
@@ -120,8 +120,7 @@
       "condensation": "N318151"
     },
     "damagedOrStuckDoors": {
-      "internalDoorIssue": "N330007",
-      "lockOnDoor": "N391707"
+      "internalDoorIssue": "N330007"
     }
   },
   "livingAreas": {
@@ -146,8 +145,7 @@
       "condensation": "N318151"
     },
     "damagedOrStuckDoors": {
-      "internalDoorIssue": "N330007",
-      "lockOnDoor": ""
+      "internalDoorIssue": "N330007"
     },
     "stairs": {
       "damagedSteps": "N351003",


### PR DESCRIPTION
Have kept single 3rd level option due to front end having multiple options where only one has a SoR (the others are exits).
A value needs to be recorded to remember which option was selected for if/when user revisits selection page.

To defer effort of creating mechanism to remove 3rd level value only when _appropriate_ for API requests, have retained single 3rd level option.