### PR TITLE
Removing CosmosDb health check due to conflict

### DIFF
--- a/HousingRepairsOnlineApi/HousingRepairsOnlineApi.csproj
+++ b/HousingRepairsOnlineApi/HousingRepairsOnlineApi.csproj
@@ -7,7 +7,6 @@
   <ItemGroup>
     <PackageReference Include="Ardalis.GuardClauses" Version="3.3.0" />
     <PackageReference Include="AspNetCore.HealthChecks.AzureStorage" Version="6.0.3" />
-    <PackageReference Include="AspNetCore.HealthChecks.CosmosDb" Version="6.0.1" />
     <PackageReference Include="AspNetCore.HealthChecks.Uris" Version="6.0.2" />
     <PackageReference Include="Azure.Cosmos" Version="4.0.0-preview3" />
     <PackageReference Include="Azure.Storage.Blobs" Version="12.10.0" />

--- a/HousingRepairsOnlineApi/Startup.cs
+++ b/HousingRepairsOnlineApi/Startup.cs
@@ -133,16 +133,12 @@ namespace HousingRepairsOnlineApi
                 c.AddJwtSecurityScheme();
             });
 
-            var cosmosEndpointUrl = GetEnvironmentVariable("COSMOS_ENDPOINT_URL");
-            var cosmosAuthorizationKey = GetEnvironmentVariable("COSMOS_AUTHORIZATION_KEY");
-            var cosmosDatabaseId = GetEnvironmentVariable("COSMOS_DATABASE_ID");
             var storageConnectionString = Environment.GetEnvironmentVariable("AZURE_STORAGE_CONNECTION_STRING");
             var blobContainerName = Environment.GetEnvironmentVariable("STORAGE_CONTAINER_NAME");
 
             services.AddHealthChecks()
                 .AddUrlGroup(new Uri(@$"{addressesApiUrl}/health"), "Addresses API")
                 .AddUrlGroup(new Uri(@$"{schedulingApiUrl}/health"), "Scheduling API")
-                .AddCosmosDb($"AccountEndpoint={cosmosEndpointUrl};AccountKey={cosmosAuthorizationKey};", cosmosDatabaseId, name: "Azure CosmosDb")
                 .AddAzureBlobStorage(storageConnectionString, blobContainerName, name: "Azure Blob Storage");
         }
 


### PR DESCRIPTION
The conflict is between AspNetCore.HealthChecks.CosmosDb (6.0.1) and Azure.Cosmos (4.0.0-preview3).

Replacing with `Microsoft.Azure.Cosmos` (3.25.0) would be the solution.
Most of the changes are drop-in replacements, however saving to Cosmos was not possible due to lack of 'id' being provided, even when the id had been provided.

Removing health check and will continue trying to solve the problem too.