### PR TITLE
Re-add Cosmos DB health check

### DIFF
--- a/HousingRepairsOnlineApi/Domain/Repair.cs
+++ b/HousingRepairsOnlineApi/Domain/Repair.cs
@@ -1,10 +1,10 @@
-﻿using System.Text.Json.Serialization;
+﻿using Newtonsoft.Json;
 
 namespace HousingRepairsOnlineApi.Domain
 {
     public class Repair
     {
-        [JsonPropertyName("id")]
+        [JsonProperty("id")]
         public string Id { get; set; }
         public string Postcode { get; set; }
         public string SOR { get; set; }

--- a/HousingRepairsOnlineApi/Gateways/CosmosGateway.cs
+++ b/HousingRepairsOnlineApi/Gateways/CosmosGateway.cs
@@ -1,17 +1,17 @@
 ﻿using System;
 using System.Threading.Tasks;
-using Azure.Cosmos;
 using HousingRepairsOnlineApi.Domain;
 using HousingRepairsOnlineApi.Helpers;
+using Microsoft.Azure.Cosmos;
 
 namespace HousingRepairsOnlineApi.Gateways
 {
     public class CosmosGateway : IRepairStorageGateway
     {
-        private CosmosContainer cosmosContainer;
+        private Container cosmosContainer;
         private readonly IIdGenerator idGenerator;
 
-        public CosmosGateway(CosmosContainer cosmosContainer, IIdGenerator idGenerator)
+        public CosmosGateway(Container cosmosContainer, IIdGenerator idGenerator)
         {
             this.cosmosContainer = cosmosContainer;
             this.idGenerator = idGenerator;
@@ -28,7 +28,7 @@ namespace HousingRepairsOnlineApi.Gateways
             {
                 ItemResponse<Repair> itemResponse = await cosmosContainer.CreateItemAsync(repair);
 
-                return itemResponse.Value;
+                return itemResponse.Resource;
             }
             catch (CosmosException ex)
             {

--- a/HousingRepairsOnlineApi/HousingRepairsOnlineApi.csproj
+++ b/HousingRepairsOnlineApi/HousingRepairsOnlineApi.csproj
@@ -7,14 +7,15 @@
   <ItemGroup>
     <PackageReference Include="Ardalis.GuardClauses" Version="3.3.0" />
     <PackageReference Include="AspNetCore.HealthChecks.AzureStorage" Version="6.0.3" />
+    <PackageReference Include="AspNetCore.HealthChecks.CosmosDb" Version="6.0.1" />
     <PackageReference Include="AspNetCore.HealthChecks.Uris" Version="6.0.2" />
-    <PackageReference Include="Azure.Cosmos" Version="4.0.0-preview3" />
     <PackageReference Include="Azure.Storage.Blobs" Version="12.10.0" />
     <PackageReference Include="GovukNotify" Version="4.0.1" />
     <PackageReference Include="HACT.Dtos" Version="1.1.0" />
     <PackageReference Include="HousingRepairsOnline.Authentication" Version="1.1.0" />
     <PackageReference Include="JWT" Version="8.4.2" />
     <PackageReference Include="JWT.Extensions.AspNetCore" Version="7.3.3" />
+    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.25.0" />
     <PackageReference Include="Sentry.AspNetCore" Version="3.13.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="5.6.3" />
     <PackageReference Include="System.IO.Abstractions" Version="13.2.47" />

--- a/HousingRepairsOnlineApi/Startup.cs
+++ b/HousingRepairsOnlineApi/Startup.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Net.Http;
 using System.Threading.Tasks;
-using Azure.Cosmos;
 using Azure.Storage.Blobs;
 using HousingRepairsOnline.Authentication.DependencyInjection;
 using HousingRepairsOnlineApi.Gateways;
@@ -9,6 +8,7 @@ using HousingRepairsOnlineApi.Helpers;
 using HousingRepairsOnlineApi.UseCases;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.Azure.Cosmos;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
@@ -133,12 +133,16 @@ namespace HousingRepairsOnlineApi
                 c.AddJwtSecurityScheme();
             });
 
+            var cosmosEndpointUrl = GetEnvironmentVariable("COSMOS_ENDPOINT_URL");
+            var cosmosAuthorizationKey = GetEnvironmentVariable("COSMOS_AUTHORIZATION_KEY");
+            var cosmosDatabaseId = GetEnvironmentVariable("COSMOS_DATABASE_ID");
             var storageConnectionString = Environment.GetEnvironmentVariable("AZURE_STORAGE_CONNECTION_STRING");
             var blobContainerName = Environment.GetEnvironmentVariable("STORAGE_CONTAINER_NAME");
 
             services.AddHealthChecks()
                 .AddUrlGroup(new Uri(@$"{addressesApiUrl}/health"), "Addresses API")
                 .AddUrlGroup(new Uri(@$"{schedulingApiUrl}/health"), "Scheduling API")
+                .AddCosmosDb($"AccountEndpoint={cosmosEndpointUrl};AccountKey={cosmosAuthorizationKey};", cosmosDatabaseId, name: "Azure CosmosDb")
                 .AddAzureBlobStorage(storageConnectionString, blobContainerName, name: "Azure Blob Storage");
         }
 


### PR DESCRIPTION
Resolved conflict between AspNetCore.HealthChecks.CosmosDb (6.0.1) and Azure.Cosmos (4.0.0-preview3) by replacing Azure.Cosmos with Microsoft.Azure.Cosmos